### PR TITLE
Fixes issue when observing elements within a non-body/html scrollable area

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ _options:_
 - `once` (boolean): Only trigger the step to enter once then remove listener. **(default: false)**
 - `debug` (boolean): Whether to show visual debugging tools or not. **(default:
   false)**
+- `scrollContainer` (DOMElement): Provide a custom element that all calculations should be relative to. Only for use if the observed elements are in a scrolling container that is *not* the `body` or `html` element **(default:
+  false)**
 
 #### scrollama.onStepEnter(callback)
 

--- a/dev/custom-container.html
+++ b/dev/custom-container.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<title>Scrollama Demo: Basic</title>
+	<meta name="description" content="Scrollama Demo: Basic">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<style>
+		/* default / demo page */
+
+		* {
+			box-sizing: border-box;
+		}
+
+		html,
+		body {
+			margin: 0;
+			padding: 0;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		}
+
+		body {
+			font-weight: 300;
+			color: #2a2a2a;
+			height: 100vh;
+		}
+
+		main {
+			overflow-y: scroll;
+			height: 100vh;
+			width: 100vw;
+		}
+
+		p,
+		h1,
+		h2,
+		h3,
+		h4,
+		a {
+			margin: 0;
+			font-weight: 300;
+		}
+
+		a,
+		a:visited,
+		a:hover {
+			color: #f30;
+			text-decoration: none;
+			border-bottom: 1px solid currentColor;
+		}
+
+		#intro {
+			max-width: 40rem;
+			margin: 1rem auto;
+			text-align: center;
+		}
+
+		.intro__overline {
+			font-size: 1.4rem;
+		}
+
+		.intro__hed {
+			font-size: 1.4rem;
+			margin: 1.5rem auto;
+			text-transform: uppercase;
+			font-weight: 900;
+			letter-spacing: 0.05em;
+		}
+
+		.intro__dek {
+			font-size: 1.4rem;
+		}
+
+		/* demo */
+
+		#intro {
+			margin-bottom: 300px;
+		}
+
+		#outro {
+			height: 4400px;
+		}
+
+		/* scrollama */
+
+		#scroll {
+			position: relative;
+		}
+
+		.scroll__text {
+			position: relative;
+			padding: 0 1rem;
+			margin: 0 auto;
+			width: 33%;
+		}
+
+		.step {
+			margin: 2rem auto 4rem auto;
+			border: 1px solid #333;
+		}
+
+		.step.is-active {
+			background-color: lightgoldenrodyellow;
+		}
+
+		.step p {
+			text-align: center;
+			padding: 1rem;
+			font-size: 1.5rem;
+		}
+
+		nav {
+			position: fixed;
+			top: 0;
+			left: 0;
+			z-index: 1000;
+			background: white;
+			padding: 1rem;
+		}
+
+
+	</style>
+
+</head>
+
+<body>
+	<main data-scrollama-container>
+
+
+	<nav>
+		<a href='#anchor-1'>Jump to 1</a>
+		<a href='#anchor-2'>Jump to 2</a>
+		<a href='#anchor-3'>Jump to 3</a>
+		<a href='#anchor-4'>Jump to 4</a>
+		<a href='#anchor-5'>Jump to 5</a>
+	</nav>
+
+	<div id='anchor-1'></div>
+
+	<section id='intro'>
+		<p class='intro__overline'>
+			<a href='https://github.com/russellgoldenberg/scrollama'>scrollama.js</a>
+		</p>
+		<h1 class='intro__hed'>Demo: Basic</h1>
+		<p class='intro__dek'>
+			Start scrolling to see how it works.
+		</p>
+	</section>
+
+	<div id='anchor-2'></div>
+	<section id='scroll'>
+		<div class='scroll__text'>
+			<div class='step' data-step='1'>
+				<p>STEP 1</p>
+			</div>
+			<div class='step' data-step='2'>
+				<p>STEP 2</p>
+			</div>
+
+			<div class='step' data-step='3'>
+
+				<p>STEP 3</p>
+				<div id='anchor-3'></div>
+			</div>
+			<div class='step' data-step='4'>
+
+				<p>STEP 4</p>
+
+			</div>
+
+		</div>
+	</section>
+	<div id='anchor-4'></div>
+	<section id='outro'></section>
+	<div id='anchor-5'></div>
+
+	</main>
+
+	<script src='https://unpkg.com/intersection-observer@0.5.0/intersection-observer.js'></script>
+	<script src='../build/scrollama.js'></script>
+	<script>
+		var container = document.querySelector('#scroll');
+		var text = container.querySelector('.scroll__text');
+		var steps = text.querySelectorAll('.step');
+
+		// initialize the scrollama
+		var scroller = scrollama();
+
+		// scrollama event handlers
+		function handleStepEnter(response) {
+			// response = { element, direction, index }
+			console.log(response.index, '-------- enter');
+			// add to color to current step
+			response.element.classList.add('is-active');
+		}
+
+		function handleStepExit(response) {
+			// response = { element, direction, index }
+			console.log(response.index, '-------- exit');
+			// remove color from current step
+			response.element.classList.remove('is-active');
+		}
+
+		function handleStepProgress(response) {
+			// response = { element, progress, index }
+			console.log(response.index, '-------- progress -', response.progress);
+		}
+
+		function init() {
+			// set random padding for different step heights (not required)
+			steps.forEach(function (step) {
+				var v = 100 + Math.floor(Math.random() * window.innerHeight / 4);
+				// step.style.padding = v + 'px 0px';
+				step.style.height = '300px';
+			});
+
+			// 1. setup the scroller with the bare-bones options
+			// this will also initialize trigger observations
+			// 3. bind scrollama event handlers (this can be chained like below)
+			scroller.setup({
+				step: '.scroll__text .step',
+				debug: true,
+				offset: 0.2,
+				// progress: true,
+			})
+				.onStepEnter(handleStepEnter)
+				.onStepExit(handleStepExit)
+				// .onStepProgress(handleStepProgress)
+
+			// setup resize event
+			window.addEventListener('resize', scroller.resize);
+		}
+
+		// kick things off
+		init();
+	</script>
+</body>
+
+</html>

--- a/src/init.js
+++ b/src/init.js
@@ -27,7 +27,7 @@ function scrollama() {
   let offsetMargin = 0;
   let viewH = 0;
   let pageH = 0;
-  let previousYOffset = 0;
+  let previousAmountScrolled = 0;
   let progressThreshold = 0;
 
   let isReady = false;
@@ -39,6 +39,8 @@ function scrollama() {
   let triggerOnce = false;
 
   let direction = 'down';
+
+  let customScrollContainer = false;
 
   const exclude = [];
 
@@ -71,14 +73,25 @@ function scrollama() {
   function getPageHeight() {
     const body = document.body;
     const html = document.documentElement;
-
-    return Math.max(
-      body.scrollHeight,
-      body.offsetHeight,
-      html.clientHeight,
-      html.scrollHeight,
-      html.offsetHeight
-    );
+    if (customScrollContainer) {
+      return Math.max(
+        customScrollContainer.scrollHeight,
+        customScrollContainer.offsetHeight,
+        body.scrollHeight,
+        body.offsetHeight,
+        html.clientHeight,
+        html.scrollHeight,
+        html.offsetHeight
+      );
+    } else {
+      return Math.max(
+        body.scrollHeight,
+        body.offsetHeight,
+        html.clientHeight,
+        html.scrollHeight,
+        html.offsetHeight
+      );
+    }
   }
 
   function getIndex(element) {
@@ -86,9 +99,17 @@ function scrollama() {
   }
 
   function updateDirection() {
-    if (window.pageYOffset > previousYOffset) direction = 'down';
-    else if (window.pageYOffset < previousYOffset) direction = 'up';
-    previousYOffset = window.pageYOffset;
+    let amountScrolled = 0;
+
+    if (customScrollContainer) {
+      amountScrolled = customScrollContainer.scrollTop;
+    } else {
+      amountScrolled = window.pageYOffset;
+    }
+
+    if (amountScrolled > previousAmountScrolled) direction = 'down';
+    else if (amountScrolled < previousAmountScrolled) direction = 'up';
+    previousAmountScrolled = amountScrolled;
   }
 
   function disconnectObserver(name) {
@@ -440,7 +461,8 @@ function scrollama() {
     threshold = 4,
     debug = false,
     order = true,
-    once = false
+    once = false,
+    scrollContainer = false
   }) => {
     // create id unique to this scrollama instance
     id = generateInstanceID();
@@ -457,6 +479,7 @@ function scrollama() {
     progressMode = progress;
     preserveOrder = order;
     triggerOnce = once;
+    customScrollContainer = scrollContainer;
 
     S.offsetTrigger(offset);
     progressThreshold = Math.max(1, +threshold);


### PR DESCRIPTION
Currently if you put the elements you wish to observe inside an element that is forced to be a certain size, but is scrollable, the `onStepEnter`/`onStepExit` handlers only fire when scrolling down. This is because the library currently assumes that the body or html elements are the scrollable areas so uses those for a few calculations.

I've resolved this in this PR by allowing the developer to pass a custom `scrollContainer` that if passed is used to calculate the total scroll height and scroll position.

I do wonder if there is a better name than `scrollContainer` - more than happy to take suggestions here and overall :)