### PR TITLE
feat: support pixel offset

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -101,7 +101,7 @@ function scrollama() {
     viewH = window.innerHeight;
     pageH = getPageHeight();
 
-    offsetMargin = offsetVal * viewH;
+    offsetMargin = offsetVal > 1 ? offsetVal : offsetVal * viewH;
 
     if (isReady) {
       stepOffsetHeight = stepEl.map(el => el.getBoundingClientRect().height);
@@ -499,9 +499,8 @@ function scrollama() {
 
   S.offsetTrigger = x => {
     if (x && !isNaN(x)) {
-      if (x > 1) console.error('scrollama error: offset value is greater than 1. Fallbacks to 1.');
       if (x < 0) console.error('scrollama error: offset value is lower than 0. Fallbacks to 0.');
-      offsetVal = Math.min(Math.max(0, x), 1);
+      offsetVal = Math.max(0, x);
       return S;
     } else if (isNaN(x)) {
       console.error('scrollama error: offset value is not a number. Fallbacks to 0.');


### PR DESCRIPTION
## feature/pixel-offset-support
Hi Russell~ I'm using your awesome `scrollama` to build a toc, which looks like the one in [Ant Design](https://ant.design/docs/react/introduce).

![image](https://user-images.githubusercontent.com/33339553/63738771-73484100-c8bd-11e9-9184-52498488c85f.png)

But mine is a little different that my page has a `60px` high header, so I want it to trigger at a absolute offset like `62px` or `64px`.

I modified some code on my fork and it just works well, any ideas?