### PR TITLE
Bugfix: specifying a container element breaks scroll direction and progress

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -27,7 +27,7 @@ function scrollama() {
   let offsetMargin = 0;
   let viewH = 0;
   let pageH = 0;
-  let previousScrolledPx = 0;
+  let previousPageYOffset = 0;
   let progressThreshold = 0;
 
   let isReady = false;
@@ -86,11 +86,11 @@ function scrollama() {
   }
 
   function updateDirection() {
-    const scrolledPx = containerEl ? containerEl.scrollTop : window.pageYOffset;
+    const pageYOffset = window.pageYOffset;
 
-    if (scrolledPx > previousScrolledPx) direction = 'down';
-    else if (scrolledPx < previousScrolledPx) direction = 'up';
-    previousScrolledPx = scrolledPx;
+    if (pageYOffset > previousPageYOffset) direction = 'down';
+    else if (pageYOffset < previousPageYOffset) direction = 'up';
+    previousPageYOffset = pageYOffset;
   }
 
   function disconnectObserver(name) {


### PR DESCRIPTION
In version 2 of scrollama, setting a `container` element while also using `progress: true` in the scrollama `setup()` function breaks the progress functionality.  When container elements are specified in the setup, progress events are only triggered when steps are entered from above, not when they are entered from below.

To reproduce:
1. In the `progress.html` example of scrollama, add a container element to the setup in [this line of the progress.html script](https://github.com/russellgoldenberg/scrollama/blob/7b4e9217f755b214fa452e028e38822215913282/dev/progress.html#L173) (just add `container: container` to the setup properties).
2. Start the dev server and view the progress example.
3. Scroll past any step, then try to scroll back up

Result:
When scrolling past a step, progress events are only triggered when steps are entered from above, not when they are entered from below. Scrolling past a step, then scrolling back up through that step does not trigger progress events.

Expected Result:
When entering an element from below (scrolling upwards), scroll progress events should be triggered as in previous versions of scrollama.

Suggested Bugfix: revert to always using `window.pageYOffset` to determine scroll direction, not `containerEl.scrollTop` for scrollama instances with containers. In my testing I found that `containerEl.scrollTop` is always 0 or constant when scrolling, resulting in the `direction` never being reset properly.