### PR TITLE
Fix enable/disable functionality

### DIFF
--- a/dev/enable-disable.html
+++ b/dev/enable-disable.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html>
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Scrollama Demo: Enable/Disable</title>
+    <meta name="description" content="Scrollama Demo: Basic">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      /* default / demo page */
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      }
+
+      body {
+        min-height: 1280px;
+        font-weight: 300;
+        color: #2a2a2a;
+      }
+
+      p,
+      h1,
+      h2,
+      h3,
+      h4,
+      a {
+        margin: 0;
+        font-weight: 300;
+      }
+
+      a,
+      a:visited,
+      a:hover {
+        color: #f30;
+        text-decoration: none;
+        border-bottom: 1px solid currentColor;
+      }
+
+      #eventsToggle {
+        margin: 30px;
+        font-size: 1.5rem;
+      }
+
+      #intro {
+        max-width: 40rem;
+        margin: 1rem auto;
+        text-align: center;
+      }
+
+      .intro__overline {
+        font-size: 1.4rem;
+      }
+
+      .intro__hed {
+        font-size: 1.4rem;
+        margin: 1.5rem auto;
+        text-transform: uppercase;
+        font-weight: 900;
+        letter-spacing: 0.05em;
+      }
+
+      .intro__dek {
+        font-size: 1.4rem;
+      }
+
+      /* demo */
+
+      #intro {
+        margin-bottom: 320px;
+      }
+
+      #outro {
+        height: 640px;
+      }
+
+      /* scrollama */
+
+      #scroll {
+        position: relative;
+      }
+
+      .scroll__text {
+        position: relative;
+        padding: 0 1rem;
+        margin: 0 auto;
+        width: 33%;
+      }
+
+      .step {
+        margin: 2rem auto 4rem auto;
+        border: 1px solid #333;
+      }
+
+      .step.is-active {
+        background-color: lightgoldenrodyellow;
+      }
+
+      .step p {
+        text-align: center;
+        padding: 1rem;
+        font-size: 1.5rem;
+      }
+    </style>
+
+  </head>
+
+  <body>
+    <section id='intro'>
+      <p class='intro__overline'>
+        <a href='https://github.com/russellgoldenberg/scrollama'>scrollama.js</a>
+      </p>
+      <h1 class='intro__hed'>Demo: Enable & Disable Events</h1>
+      <p class='intro__dek'>
+        Start scrolling to see how it works. Click below to enable or disable the scroller.
+      </p>
+      <button id="eventsToggle">Click to Disable Events</button>
+    </section>
+    <section id='scroll'>
+      <div class='scroll__text'>
+        <div class='step' data-step='1'>
+          <p>STEP 1</p>
+        </div>
+        <div class='step' data-step='2'>
+          <p>STEP 2</p>
+        </div>
+      </div>
+    </section>
+    <section id='outro'></section>
+    <script src='https://unpkg.com/intersection-observer@0.5.0/intersection-observer.js'></script>
+    <script src='../build/scrollama.js'></script>
+    <script src='d3.v4.min.js'></script>
+    <script>
+      var container = document.querySelector('#scroll');
+      var text = container.querySelector('.scroll__text');
+      var steps = text.querySelectorAll('.step');
+      var enableDisableButton = document.querySelector('#eventsToggle');
+      var isEnabled = true;
+
+      // initialize the scrollama
+      var scroller = scrollama();
+
+      // scrollama event handlers
+      function handleStepEnter(response) {
+        // response = { element, direction, index }
+        console.log('enter', response);
+        // add to color to current step
+        response.element.classList.add('is-active');
+      }
+
+      function handleStepExit(response) {
+        // response = { element, direction, index }
+        console.log('exit', response);
+        // remove color from current step
+        response.element.classList.remove('is-active');
+      }
+
+      function handleStepProgress(response) {
+        console.log(response.progress)
+        d3.select(response.element).select('p').text(d3.format('.1%')(response.progress))
+      }
+
+      function handleEnableStateChange() {
+        if (isEnabled) {
+          scroller.disable();
+          enableDisableButton.innerHTML = 'Click to Enable Events';
+        } else {
+          scroller.enable();
+          enableDisableButton.innerHTML = 'Click to Disable Events';
+        }
+        isEnabled = !isEnabled;
+      }
+
+      function init() {
+        // set random padding for different step heights (not required)
+        steps.forEach(function (step) {
+          var v = 100 + Math.floor(Math.random() * window.innerHeight / 4);
+          step.style.padding = v + 'px 0px';
+        });
+
+        // 1. setup the scroller with the bare-bones options
+        // this will also initialize trigger observations
+        // 3. bind scrollama event handlers (this can be chained like below)
+        scroller.setup({
+            step: '.scroll__text .step',
+            debug: true,
+            progress: true,
+          })
+          .onStepEnter(handleStepEnter)
+          .onStepExit(handleStepExit)
+          .onStepProgress(handleStepProgress);
+
+        // setup resize event
+        window.addEventListener('resize', scroller.resize);
+
+        // handle enable/disable button clicks
+        enableDisableButton.addEventListener('click', handleEnableStateChange);
+      }
+
+      // kick things off
+      init();
+    </script>
+  </body>
+
+</html>

--- a/src/init.js
+++ b/src/init.js
@@ -113,13 +113,19 @@ function scrollama() {
   }
 
   function handleEnable(enable) {
-    if (enable && !isEnabled) {
-      if (isReady) updateIO();
-      isEnabled = true;
-      return true;
+    if (enable && !isEnabled) { // enable a disabled scroller
+      if (isReady) { // enable a ready scroller
+        updateIO();
+      } else { // can't enable an unready scroller
+        console.error('scrollama error: enable() called before scroller was ready');
+        isEnabled = false;
+        return; // all is not well, don't set the requested state
+      }
     }
-    OBSERVER_NAMES.forEach(disconnectObserver);
-    isEnabled = false;
+    if (!enable && isEnabled) { // disable an enabled scroller
+      OBSERVER_NAMES.forEach(disconnectObserver);
+    }
+    isEnabled = enable; // all is well, set requested state
   }
 
   function createThreshold(height) {

--- a/src/init.js
+++ b/src/init.js
@@ -383,7 +383,7 @@ function scrollama() {
 
   // look below for intersection
   function updateStepBelowIO() {
-    io.stepAbove = stepEl.map((el, i) => {
+    io.stepBelow = stepEl.map((el, i) => {
       const marginTop = -offsetMargin;
       const marginBottom = offsetMargin - viewH + stepOffsetHeight[i];
       const rootMargin = `${marginTop}px 0px ${marginBottom}px 0px`;


### PR DESCRIPTION
There seem to be several issues with enabling and disabling scrollers that this PR fixes:
1) The logic in `handleEnable()` disables the scroller when `handleEnable()` is called with `isEnabled === true`.  In other words `scroller.enable(); scroller.enable();` will disable the scroller.
2) Some events were not fully disabled because of an incorrectly named variable (`io.stepAbove` should be named `io.stepBelow` in `updateStepBelowIO()`).

I'm not sure how applicable the error handling I added in `handleEnable()` is, but it seems like a good thing to check for.

I also added an example html file `dev/enable-disable.html`, which is also useful for debugging.