### PR TITLE
Change step type to array of elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ window.addEventListener("resize", scroller.resize);
 
 _options:_
 
-- `step` (string): Selector (or array of elements) for the step elements that will trigger changes.
+- `step` (string | HTMLElement[]): Selector (or array of elements) for the step elements that will trigger changes.
   **required**
 - `offset` (number 0 - 1, or string with "px"): How far from the top of the viewport to trigger a step. **(default: 0.5) (middle of screen)**
 - `progress` (boolean): Whether to fire incremental step progress updates or

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare namespace scrollama {
   export type DecimalType = 0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1;
 
   export type ScrollamaOptions = {
-    step: HTMLElement | string;
+    step: HTMLElement[] | string;
     progress?: boolean;
     offset?: DecimalType;
     threshold?: 1 | 2 | 3 | 4;


### PR DESCRIPTION
As per the documentation: 

> `step` (string): Selector (or array of elements)