### PR TITLE
make importing side-effect free

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -226,6 +226,8 @@ function scrollama() {
 	}
 
 	/* SETUP */
+	setupScroll();
+
 	const S = {};
 
 	S.setup = ({
@@ -313,7 +315,5 @@ function scrollama() {
 	};
 	return S;
 }
-
-setupScroll();
 
 export default scrollama;


### PR DESCRIPTION
fixes #130 

Thanks for this library! It's certainly the de facto scrollytelling library.

I'd like to propose moving `setupScroll` to the body of the `scrollama` default export. Calling a function in the module body will run that function during import, which throws an error in node environments due to `document` not being defined.

The docs specify that we ought to invoke the imported `scrollama` function before use, so I don't think this change will break any expected behavior. I've tested the examples in the `docs` folder locally and all looks good.